### PR TITLE
Enable usage of self-signed certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,11 @@ restic_resource_allocation:
       memory: 128Mi
   ```
 
+### Use Velero with a storage provider secured by a self-signed certificate
+
+If you are using an S3-Compatible storage provider that is secured with a self-signed certificate, connections to the object store may fail with a `certificate signed by unknown authority` message. In order to proceed, you will have to specify the a base64 encoded certificate string as a value of the `caCert` spec under the `object_storage` configuration in the velero CR.
+
+
 ### Cleanup
 For cleaning up the deployed resources, use the following commands:
 ```

--- a/roles/velero/defaults/main.yml
+++ b/roles/velero/defaults/main.yml
@@ -22,7 +22,7 @@ velero_image: "{{ registry }}/{{ project }}/{{ velero_repo }}"
 velero_repo: "{{ lookup( 'env', 'VELERO_REPO') }}"
 velero_version: "{{ velero_upstream_tag if use_upstream_images is defined and use_upstream_images|bool == true else lookup( 'env', 'VELERO_TAG') }}"
 velero_image_fqin: "{{ velero_image }}:{{ velero_version }}"
-velero_openshift_plugin_image: "{{ registry }}/{{ project }}/{{ velero_openshift_plugin_repo }}"
+velero_openshift_plugin_image: "{{ quay_registry }}/{{ konveyor_project }}/{{ velero_openshift_plugin_repo }}"
 velero_openshift_plugin_repo: "{{ lookup( 'env', 'VELERO_OPENSHIFT_PLUGIN_REPO') }}"
 velero_openshift_plugin_version: "{{ lookup( 'env', 'VELERO_OPENSHIFT_PLUGIN_TAG') }}"
 velero_csi_plugin_image: "{{ upstream_registry }}/{{ velero_upstream_project }}/{{ velero_csi_plugin_repo }}"
@@ -46,3 +46,5 @@ size: 1
 volume_snapshot_locations: []
 enable_restic: true
 upstream_registry: docker.io
+quay_registry: quay.io
+konveyor_project: konveyor

--- a/roles/velero/tasks/main.yml
+++ b/roles/velero/tasks/main.yml
@@ -95,7 +95,7 @@
     state: "{{ velero_state }}"
     definition: "{{ lookup('template', 'velero_bsl_azure.yml.j2') }}"
   when: velero_azure_bsl_configs | int != 0
-  
+
 - name: "Create VolumeStorageLocations"
   k8s:
     state: "{{ velero_state }}"

--- a/roles/velero/tasks/preflight.yml
+++ b/roles/velero/tasks/preflight.yml
@@ -16,7 +16,7 @@
   block:
     - set_fact:
         decoded_ca_cert: "{{ aws_bsl_res.object_storage.ca_cert | b64decode }}"
-      when: velero_aws_bsl_configs | int == 1 and aws_bsl_res.object_storage.ca_cert | length > 0 
+      when: velero_aws_bsl_configs | int == 1 and aws_bsl_res.object_storage.ca_cert | length > 0
   rescue:
     - fail:
         msg: "The provided caCert for aws is not in valid base64 format"
@@ -38,7 +38,7 @@
   block:
     - set_fact:
         decoded_ca_cert: "{{ gcp_bsl_res.object_storage.ca_cert | b64decode }}"
-      when: velero_gcp_bsl_configs | int == 1 and gcp_bsl_res.object_storage.ca_cert | length > 0 
+      when: velero_gcp_bsl_configs | int == 1 and gcp_bsl_res.object_storage.ca_cert | length > 0
   rescue:
     - fail:
         msg: "The provided caCert for gcp is not in valid base64 format"
@@ -55,12 +55,12 @@
   fail:
     msg: "More than one BackupStorageLocations are configured for azure"
   when: velero_azure_bsl_configs | int > 1
- 
+
 - name: "Decode and validate caCert if defined for azure"
   block:
     - set_fact:
         decoded_ca_cert: "{{ azure_bsl_res.object_storage.ca_cert | b64decode }}"
-      when: velero_azure_bsl_configs | int == 1 and azure_bsl_res.object_storage.ca_cert | length > 0 
+      when: velero_azure_bsl_configs | int == 1 and azure_bsl_res.object_storage.ca_cert | length > 0
   rescue:
     - fail:
         msg: "The provided caCert for azure is not in valid base64 format"

--- a/roles/velero/tasks/preflight.yml
+++ b/roles/velero/tasks/preflight.yml
@@ -3,6 +3,7 @@
   set_fact:
     velero_aws_secret_name: "{{ item.credentials_secret_ref.name }}"
     velero_aws_bsl_configs: "{{ velero_aws_bsl_configs | int + 1 }}"
+    aws_bsl_res: "{{ item }}"
   loop: "{{ backup_storage_locations }}"
   when: item.provider == 'aws'
 
@@ -11,10 +12,20 @@
     msg: "More than one BackupStorageLocations are configured for aws"
   when: velero_aws_bsl_configs | int > 1
 
+- name: "Decode and validate caCert if defined for aws"
+  block:
+    - set_fact:
+        decoded_ca_cert: "{{ aws_bsl_res.object_storage.ca_cert | b64decode }}"
+      when: velero_aws_bsl_configs | int == 1 and aws_bsl_res.object_storage.ca_cert | length > 0 
+  rescue:
+    - fail:
+        msg: "The provided caCert for aws is not in valid base64 format"
+
 - name: "Discover gcp as provider in Backup Storage Locations and associate gcp secret name"
   set_fact:
     velero_gcp_secret_name: "{{ item.credentials_secret_ref.name }}"
     velero_gcp_bsl_configs: "{{ velero_gcp_bsl_configs | int + 1 }}"
+    gcp_bsl_res: "{{ item }}"
   loop: "{{ backup_storage_locations }}"
   when: item.provider == 'gcp'
 
@@ -23,10 +34,20 @@
     msg: "More than one BackupStorageLocations are configured for gcp"
   when: velero_gcp_bsl_configs | int > 1
 
+- name: "Decode and validate caCert if defined for gcp"
+  block:
+    - set_fact:
+        decoded_ca_cert: "{{ gcp_bsl_res.object_storage.ca_cert | b64decode }}"
+      when: velero_gcp_bsl_configs | int == 1 and gcp_bsl_res.object_storage.ca_cert | length > 0 
+  rescue:
+    - fail:
+        msg: "The provided caCert for gcp is not in valid base64 format"
+
 - name: "Discover azure as provider in Backup Storage Locations and associate azure secret name"
   set_fact:
     velero_azure_secret_name: "{{ item.credentials_secret_ref.name }}"
     velero_azure_bsl_configs: "{{ velero_azure_bsl_configs | int + 1 }}"
+    azure_bsl_res: "{{ item }}"
   loop: "{{ backup_storage_locations }}"
   when: item.provider == 'azure'
 
@@ -35,3 +56,11 @@
     msg: "More than one BackupStorageLocations are configured for azure"
   when: velero_azure_bsl_configs | int > 1
  
+- name: "Decode and validate caCert if defined for azure"
+  block:
+    - set_fact:
+        decoded_ca_cert: "{{ azure_bsl_res.object_storage.ca_cert | b64decode }}"
+      when: velero_azure_bsl_configs | int == 1 and azure_bsl_res.object_storage.ca_cert | length > 0 
+  rescue:
+    - fail:
+        msg: "The provided caCert for azure is not in valid base64 format"

--- a/roles/velero/templates/velero_bsl_aws.yml.j2
+++ b/roles/velero/templates/velero_bsl_aws.yml.j2
@@ -8,16 +8,47 @@ metadata:
   namespace: {{ velero_namespace }}
 spec:
   provider: {{ bsl.provider }}
+{% if bsl.object_storage is defined %}
   objectStorage:
+{% if bsl.object_storage.bucket is defined %}
     bucket: {{ bsl.object_storage.bucket }}
+{% endif %}
 {% if bsl.object_storage.prefix is defined %}
     prefix: {{ bsl.object_storage.prefix }}
 {% endif %}
-{% if bsl.object_storage.caCert is defined %}
-    caCert: {{ bsl.object_storage.caCert }}
+{% if bsl.object_storage.ca_cert is defined %}
+    caCert: {{ bsl.object_storage.ca_cert }}
+{% endif %}
 {% endif %}
 {% if bsl.config is defined %}
-  config: {{ bsl.config }}
+  config:
+{% if bsl.config.region is defined %}
+    region: {{ bsl.config.region }}
+{% endif %}
+{% if bsl.config.profile is defined %}
+    profile: {{ bsl.config.profile }}
+{% endif %}
+{% if bsl.config.s_3__force_path_style is defined %}
+    s3ForcePathStyle: "{{ bsl.config.s_3__force_path_style | string }}"
+{% endif %}
+{% if bsl.config.s_3__url is defined %}
+    s3Url: {{ bsl.config.s_3__url }}
+{% endif %}
+{% if bsl.config.public_url is defined %}
+    publicUrl: {{ bsl.config.public_url }} 
+{% endif %}
+{% if bsl.config.server_side_encryption is defined %}
+    serverSideEncryption: {{ bsl.config.server_side_encryption }}
+{% endif %}
+{% if bsl.config.kms_key_id is defined %}
+    kmsKeyId: {{ kms_key_id }}
+{% endif %}
+{% if bsl.config.signature_version is defined %}
+    signatureVersion: "{{ bsl.config.signature_version | string }}"
+{% endif %}
+{% if bsl.config.insecure_skip_tls_verify is defined %}
+    insecureSkipTLSVerify: "{{ bsl.config.insecure_skip_tls_verify | string }}"
+{% endif %}
 {% endif %}
   accessMode: {{ bsl.access_mode | default('ReadWrite')}}
 {% if bsl.backup_sync_period is defined %}

--- a/roles/velero/templates/velero_bsl_azure.yml.j2
+++ b/roles/velero/templates/velero_bsl_azure.yml.j2
@@ -13,8 +13,8 @@ spec:
 {% if bsl.object_storage.prefix is defined %}
     prefix: {{ bsl.object_storage.prefix }}
 {% endif %}
-{% if bsl.object_storage.caCert is defined %}
-    caCert: {{ bsl.object_storage.caCert }}
+{% if bsl.object_storage.ca_cert is defined %}
+    caCert: {{ bsl.object_storage.ca_cert }}
 {% endif %}
 {% if bsl.config is defined %}
   config:

--- a/roles/velero/templates/velero_bsl_gcp.yml.j2
+++ b/roles/velero/templates/velero_bsl_gcp.yml.j2
@@ -13,8 +13,8 @@ spec:
 {% if bsl.object_storage.prefix is defined %}
     prefix: {{ bsl.object_storage.prefix }}
 {% endif %}
-{% if bsl.object_storage.caCert is defined %}
-    caCert: {{ bsl.object_storage.caCert }}
+{% if bsl.object_storage.ca_cert is defined %}
+    caCert: {{ bsl.object_storage.ca_cert }}
 {% endif %}
 {% if bsl.config is defined %}
   config:

--- a/roles/velero/templates/velero_supporting.yml.j2
+++ b/roles/velero/templates/velero_supporting.yml.j2
@@ -1697,6 +1697,9 @@ spec:
                   description: Prefix is the path inside a bucket to use for Velero
                     storage. Optional.
                   type: string
+                caCert:
+                  description: base64 encoded string to be used when verifying TLS connections. Optional.
+                  type: string
               required:
               - bucket
               type: object


### PR DESCRIPTION
- changes to enable the usage of self-signed certs
- added validation to check whether the feeded `ca_cert` is in base64 format
- Modifications to the bsl templates to respect `ca_cert` spec
- Modifications to the bsl CRD to respect `ca_cert` spec
- `registry` and `project` path changes for `openshift-velero-plugin`
- Updated Readme