### PR TITLE
Update namespace var in velero supporting resources template

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ For cleaning up the deployed resources, use the following commands:
 ```
 oc delete -f deploy/crds/konveyor.openshift.io_v1alpha1_velero_cr.yaml
 oc delete -f deploy/crds/konveyor.openshift.io_veleros_crd.yaml   
-oc delete -f deploy/
+oc delete -f deploy/non-olm/
 oc delete namespace oadp-operator
 oc delete crd $(oc get crds | grep velero.io | awk -F ' ' '{print $1}')
 ```

--- a/roles/velero/templates/velero_supporting.yml.j2
+++ b/roles/velero/templates/velero_supporting.yml.j2
@@ -3481,7 +3481,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: velero
-  namespace: {{ mig_namespace }}
+  namespace: {{ velero_namespace }}
   labels:
     component: velero
 ---
@@ -3546,7 +3546,7 @@ metadata:
     component: velero
 subjects:
   - kind: ServiceAccount
-    namespace: {{ mig_namespace }}
+    namespace: {{ velero_namespace }}
     name: velero
 roleRef:
   kind: ClusterRole
@@ -3592,7 +3592,7 @@ supplementalGroups:
   type: RunAsAny
 users:
 - system:admin
-- system:serviceaccount:{{ mig_namespace }}:velero
+- system:serviceaccount:{{ velero_namespace }}:velero
 volumes:
 - '*'
 {% endif %}


### PR DESCRIPTION
This PR fixes the usage of undefined var `mig_namepsace` in `velero_supporting.yml.j2 `  used for non-olm operator deployment