### PR TITLE
Add vSphere plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ There are mainly two categories of velero plugins that can be specified while in
   
   Note:
   - For usage of the `csi` plugin with Velero you will need to additionally set `--features=EnableCSI`, please refer the section titled **Usage of Velero `--features` option** for more details. [This](https://github.com/vmware-tanzu/velero-plugin-for-csi/) repository has more information about the CSI plugin.
-  - Similarly, for installation of `vsphere` plugin, you will need to set `--features=EnableLocalMode`, please refer the section titled **Usage of Velero `--features` option** for more details. [This](https://github.com/vmware-tanzu/velero-plugin-for-vsphere) repository has more information about the vSphere plugin.
+  - Similarly, for installation of `vsphere` plugin, please refer the section titled **Usage of Velero `--features` option** for more details. [This](https://github.com/vmware-tanzu/velero-plugin-for-vsphere) repository has more information about the vSphere plugin.
    
 2. `custom-velero-plugin`:<br>
    For installation of custom velero plugins, you need to specify the plugin `image` and plugin `name` in the `konveyor.openshift.io_v1alpha1_velero_cr.yaml` file during deployment.
@@ -234,7 +234,7 @@ default_velero_plugins:
 velero_feature_flags:
 - EnableCSI
 ```
-- Enabling Velero plugin for vSphere: To enable vSphere plugin you need to add thre things in the `konveyor.openshift.io_v1alpha1_velero_cr.yaml` file during deployment.
+- Enabling Velero plugin for vSphere: To enable vSphere plugin you need to do the following things in the `konveyor.openshift.io_v1alpha1_velero_cr.yaml` file during deployment.
   - First, add `vsphere` under the `default_velero_plugins`
   - Second, add `EnableLocalMode` under the `velero_feature_flags`
   - Lastly, add the flag `use_upstream_images` and set it as `true`.
@@ -245,6 +245,7 @@ velero_feature_flags:
 - EnableLocalMode
 use_upstream_images: true
 ```
+Note: The above is an example of installing the Velero plugin for vSphere in `LocalMode` . Setting `EnableLocalMode` features flag is not always necessary for the usage of vSphere plugin but the pre-requisites must be satisfied and appropriate configuration must be applied, please refer [Velero plugin for vSphere](https://github.com/vmware-tanzu/velero-plugin-for-vsphere) for more details.
 
 ***
 ## OLM Integration

--- a/README.md
+++ b/README.md
@@ -178,8 +178,10 @@ There are mainly two categories of velero plugins that can be specified while in
       - csi
    ```
    The above specification will install Velero with all five default plugins. 
-
-   [This](https://github.com/vmware-tanzu/velero-plugin-for-csi/) repository has more information about the CSI plugin.
+  
+  Note:
+  - For usage of the `csi` plugin with Velero you will need to additionally set `--features=EnableCSI`, please refer the section titled **Usage of Velero `--features` option** for more details. [This](https://github.com/vmware-tanzu/velero-plugin-for-csi/) repository has more information about the CSI plugin.
+  - Similarly, for installation of `vsphere` plugin, you will need to set `--features=EnableLocalMode`, please refer the section titled **Usage of Velero `--features` option** for more details. [This](https://github.com/vmware-tanzu/velero-plugin-for-vsphere) repository has more information about the vSphere plugin.
    
 2. `custom-velero-plugin`:<br>
    For installation of custom velero plugins, you need to specify the plugin `image` and plugin `name` in the `konveyor.openshift.io_v1alpha1_velero_cr.yaml` file during deployment.
@@ -218,6 +220,31 @@ By default, the Velero deployment requests 500m CPU, 128Mi memory and sets a lim
 ### Use self-sigend certificate
 
 If you intend to use Velero with a storage provider that is secured by a self-signed certificate, you may need to instruct Velero to trust that certificate. See [Use self-sigend certificate](docs/self_signed_certs.md) section for details.
+
+### Usage of Velero `--features` option
+Some of the new features in Velero are released as beta features behind feature flags which are not enabled by default during the Velero installation. In order to provide `--features` flag values, you need to use the specify the flags under `velero_feature_flags:` in the `konveyor.openshift.io_v1alpha1_velero_cr.yaml` file during deployment.
+
+Some of the usage instances of the `--features` flag are as follows:
+- Enabling Velero plugin for CSI: To enable CSI plugin you need to add two things in the `konveyor.openshift.io_v1alpha1_velero_cr.yaml` file during deployment.
+  - First, add `csi` under the `default_velero_plugins` 
+  - Second, add `EnableCSI` under the `velero_feature_flags`
+```
+default_velero_plugins:
+- csi
+velero_feature_flags:
+- EnableCSI
+```
+- Enabling Velero plugin for vSphere: To enable vSphere plugin you need to add thre things in the `konveyor.openshift.io_v1alpha1_velero_cr.yaml` file during deployment.
+  - First, add `vsphere` under the `default_velero_plugins`
+  - Second, add `EnableLocalMode` under the `velero_feature_flags`
+  - Lastly, add the flag `use_upstream_images` and set it as `true`.
+```
+default_velero_plugins:
+- vsphere
+velero_feature_flags:
+- EnableLocalMode
+use_upstream_images: true
+```
 
 ***
 ## OLM Integration

--- a/deploy/crds/konveyor.openshift.io_v1alpha1_velero_cr.yaml
+++ b/deploy/crds/konveyor.openshift.io_v1alpha1_velero_cr.yaml
@@ -7,6 +7,7 @@ spec:
   default_velero_plugins:
   - aws
   - openshift
+  - csi
   backup_storage_locations:
   - name: default
     provider: aws
@@ -26,3 +27,5 @@ spec:
       region: us-west-2
       profile: "default"
   enable_restic: true
+  velero_feature_flags:
+  - EnableCSI

--- a/deploy/non-olm/operator.yaml
+++ b/deploy/non-olm/operator.yaml
@@ -55,6 +55,8 @@ spec:
               value: velero-plugin-for-microsoft-azure
             - name: VELERO_CSI_PLUGIN_REPO
               value: velero-plugin-for-csi
+            - name: VELERO_VSPHERE_PLUGIN_REPO
+              value: velero-plugin-for-vsphere
             - name: VELERO_TAG
               value: konveyor-1.5.2
             - name: VELERO_RESTIC_RESTORE_HELPER_TAG
@@ -67,6 +69,8 @@ spec:
               value: konveyor-1.1.0
             - name: VELERO_CSI_PLUGIN_TAG
               value: main
+            - name: VELERO_VSPHERE_PLUGIN_TAG
+              value: 1.1.0
       volumes:
         - name: runner
           emptyDir: {}

--- a/deploy/olm-catalog/bundle/manifests/oadp-operator.v0.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/oadp-operator.v0.2.0.clusterserviceversion.yaml
@@ -40,6 +40,9 @@ metadata:
               "csi",
               "openshift"
             ],
+            "velero_feature_flags": [
+              "EnableCSI"
+            ],
             "enable_restic": true,
             "volume_snapshot_locations": [
               {
@@ -224,6 +227,8 @@ spec:
                   value: velero-plugin-for-microsoft-azure
                 - name: VELERO_CSI_PLUGIN_REPO
                   value: velero-plugin-for-csi
+                - name: VELERO_VSPHERE_PLUGIN_REPO
+                  value: velero-plugin-for-vsphere
                 - name: VELERO_TAG
                   value: konveyor-1.5.2
                 - name: VELERO_RESTIC_RESTORE_HELPER_TAG
@@ -236,6 +241,8 @@ spec:
                   value: konveyor-1.1.0
                 - name: VELERO_CSI_PLUGIN_TAG
                   value: main
+                - name: VELERO_VSPHERE_PLUGIN_TAG
+                  value: 1.1.0
                 image: "quay.io/konveyor/oadp-operator:latest"
                 imagePullPolicy: Always
                 name: oadp-operator

--- a/roles/velero/defaults/main.yml
+++ b/roles/velero/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 backup_storage_locations: []
 custom_velero_plugins: []
+velero_feature_flags: []
 http_proxy: "{{ lookup( 'env', 'HTTP_PROXY') }}"
 https_proxy: "{{ lookup( 'env', 'HTTPS_PROXY') }}"
 no_proxy: "{{ lookup( 'env', 'NO_PROXY') }}"
@@ -17,7 +18,9 @@ velero_gcp_secret_name: gcp-cloud-credentials
 velero_azure_secret_name: azure-cloud-credentials
 velero_debug: false
 velero_upstream_project: velero
+velero_vsphere_upstream_project: vsphereveleroplugin
 velero_upstream_tag: v1.5.2
+velero_upstream_plugin_tag: main
 velero_image: "{{ registry }}/{{ project }}/{{ velero_repo }}"
 velero_repo: "{{ lookup( 'env', 'VELERO_REPO') }}"
 velero_version: "{{ velero_upstream_tag if use_upstream_images is defined and use_upstream_images|bool == true else lookup( 'env', 'VELERO_TAG') }}"
@@ -28,18 +31,21 @@ velero_openshift_plugin_version: "{{ lookup( 'env', 'VELERO_OPENSHIFT_PLUGIN_TAG
 velero_csi_plugin_image: "{{ upstream_registry }}/{{ velero_upstream_project }}/{{ velero_csi_plugin_repo }}"
 velero_csi_plugin_repo: "{{ lookup('env', 'VELERO_CSI_PLUGIN_REPO') }}"
 velero_csi_plugin_version: "{{ lookup('env', 'VELERO_CSI_PLUGIN_TAG') }}"
+velero_vsphere_plugin_image: "{{ upstream_registry }}/{{ velero_vsphere_upstream_project }}/{{ velero_vsphere_plugin_repo }}"
+velero_vsphere_plugin_repo: "{{ lookup('env', 'VELERO_VSPHERE_PLUGIN_REPO') }}"
+velero_vsphere_plugin_version: "{{ lookup('env', 'VELERO_VSPHERE_PLUGIN_TAG') }}"
 velero_restic_restore_helper_image: "{{ registry }}/{{ project }}/{{ velero_restic_restore_helper_repo }}"
 velero_restic_restore_helper_repo: "{{ lookup( 'env', 'VELERO_RESTIC_RESTORE_HELPER_REPO') }}"
-velero_restic_restore_helper_version: "{{ lookup( 'env', 'VELERO_RESTIC_RESTORE_HELPER_TAG') }}"
+velero_restic_restore_helper_version: "{{ velero_upstream_tag if use_upstream_images is defined and use_upstream_images|bool == true else lookup( 'env', 'VELERO_RESTIC_RESTORE_HELPER_TAG') }}"
 velero_aws_plugin_image: "{{ registry }}/{{ project }}/{{ velero_aws_plugin_repo }}"
 velero_aws_plugin_repo: "{{ lookup( 'env', 'VELERO_AWS_PLUGIN_REPO') }}"
-velero_aws_plugin_version: "{{ lookup( 'env', 'VELERO_AWS_PLUGIN_TAG') }}"
+velero_aws_plugin_version: "{{ velero_upstream_plugin_tag if use_upstream_images is defined and use_upstream_images|bool == true else lookup( 'env', 'VELERO_AWS_PLUGIN_TAG') }}"
 velero_gcp_plugin_image: "{{ registry }}/{{ project }}/{{ velero_gcp_plugin_repo }}"
 velero_gcp_plugin_repo: "{{ lookup( 'env', 'VELERO_GCP_PLUGIN_REPO') }}"
-velero_gcp_plugin_version: "{{ lookup( 'env', 'VELERO_GCP_PLUGIN_TAG') }}"
+velero_gcp_plugin_version: "{{ velero_upstream_plugin_tag if use_upstream_images is defined and use_upstream_images|bool == true else lookup( 'env', 'VELERO_GCP_PLUGIN_TAG') }}"
 velero_azure_plugin_image: "{{ registry }}/{{ project }}/{{ velero_azure_plugin_repo }}"
 velero_azure_plugin_repo: "{{ lookup( 'env', 'VELERO_AZURE_PLUGIN_REPO') }}"
-velero_azure_plugin_version: "{{ lookup( 'env', 'VELERO_AZURE_PLUGIN_TAG') }}"
+velero_azure_plugin_version: "{{ velero_upstream_plugin_tag if use_upstream_images is defined and use_upstream_images|bool == true else lookup( 'env', 'VELERO_AZURE_PLUGIN_TAG') }}"
 restic_pv_host_path: /var/lib/kubelet/pods
 restic_timeout: 1h
 size: 1

--- a/roles/velero/templates/velero.yml.j2
+++ b/roles/velero/templates/velero.yml.j2
@@ -65,9 +65,11 @@ spec:
             - server
             - --restic-timeout
             - {{ restic_timeout }}
-{% if 'csi' in default_velero_plugins %}
+{% if velero_feature_flags|length > 0 %}
             - --features
-            - EnableCSI
+{% for flag in velero_feature_flags %}
+            - {{ flag }}
+{% endfor %}
 {% endif %}
 {% if velero_debug %}
             - --log-level
@@ -194,6 +196,17 @@ spec:
         - image: {{ velero_csi_plugin_image }}:{{ velero_csi_plugin_version }}
           imagePullPolicy: "{{ image_pull_policy }}"
           name: velero-plugin-for-csi
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /target
+            name: plugins
+{% endif %}
+{% if 'vsphere' in default_velero_plugins %}
+        - image: {{ velero_vsphere_plugin_image }}:{{ velero_vsphere_plugin_version }}
+          imagePullPolicy: "{{ image_pull_policy }}"
+          name: velero-plugin-for-vsphere
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File


### PR DESCRIPTION
This PR does the following:
- Introduces a new `velero_feature_flags` spec field for the Velero CR
- Adds Velero plugin vSphere support
- Adds Documentation on the usage of `velero_feature_flags` for vSphere plugin as well as the CSI plugin
- Fixes https://github.com/konveyor/oadp-operator/issues/66