### PR TITLE
Add multiple feature flag support for Velero

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,7 @@ Some of the usage instances of the `--features` flag are as follows:
 ```
 default_velero_plugins:
 - csi
-velero_feature_flags:
-- EnableCSI
+velero_feature_flags: EnableCSI
 ```
 - Enabling Velero plugin for vSphere: To enable vSphere plugin you need to do the following things in the `konveyor.openshift.io_v1alpha1_velero_cr.yaml` file during deployment.
   - First, add `vsphere` under the `default_velero_plugins`
@@ -241,11 +240,10 @@ velero_feature_flags:
 ```
 default_velero_plugins:
 - vsphere
-velero_feature_flags:
-- EnableLocalMode
+velero_feature_flags: EnableLocalMode
 use_upstream_images: true
 ```
-Note: The above is an example of installing the Velero plugin for vSphere in `LocalMode` . Setting `EnableLocalMode` features flag is not always necessary for the usage of vSphere plugin but the pre-requisites must be satisfied and appropriate configuration must be applied, please refer [Velero plugin for vSphere](https://github.com/vmware-tanzu/velero-plugin-for-vsphere) for more details.
+Note: The above is an example of installing the Velero plugin for vSphere in `LocalMode` . Setting `EnableLocalMode` features flag is not always necessary for the usage of vSphere plugin but the pre-requisites must be satisfied and appropriate configuration must be applied, please refer [Velero plugin for vSphere](https://github.com/vmware-tanzu/velero-plugin-for-vsphere) for more details. Also, if you plan on using multiple feature flags at once, pass them to `velero_feature_flags` as comma seperated values, for instance, `velero_feature_flags: EnableLocalMode,EnableCSI`
 
 ***
 ## OLM Integration

--- a/deploy/crds/konveyor.openshift.io_v1alpha1_velero_cr.yaml
+++ b/deploy/crds/konveyor.openshift.io_v1alpha1_velero_cr.yaml
@@ -27,5 +27,4 @@ spec:
       region: us-west-2
       profile: "default"
   enable_restic: true
-  velero_feature_flags:
-  - EnableCSI
+  velero_feature_flags: EnableCSI

--- a/deploy/olm-catalog/bundle/manifests/oadp-operator.v0.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/oadp-operator.v0.2.0.clusterserviceversion.yaml
@@ -40,9 +40,7 @@ metadata:
               "csi",
               "openshift"
             ],
-            "velero_feature_flags": [
-              "EnableCSI"
-            ],
+            "velero_feature_flags": "EnableCSI",
             "enable_restic": true,
             "volume_snapshot_locations": [
               {

--- a/roles/velero/defaults/main.yml
+++ b/roles/velero/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 backup_storage_locations: []
 custom_velero_plugins: []
-velero_feature_flags: []
 http_proxy: "{{ lookup( 'env', 'HTTP_PROXY') }}"
 https_proxy: "{{ lookup( 'env', 'HTTPS_PROXY') }}"
 no_proxy: "{{ lookup( 'env', 'NO_PROXY') }}"

--- a/roles/velero/templates/velero.yml.j2
+++ b/roles/velero/templates/velero.yml.j2
@@ -65,7 +65,7 @@ spec:
             - server
             - --restic-timeout
             - {{ restic_timeout }}
-{% if velero_feature_flags is defined %}
+{% if velero_feature_flags is defined and velero_feature_flags|length > 0 %}
             - --features
             - {{ velero_feature_flags }}
 {% endif %}

--- a/roles/velero/templates/velero.yml.j2
+++ b/roles/velero/templates/velero.yml.j2
@@ -65,11 +65,9 @@ spec:
             - server
             - --restic-timeout
             - {{ restic_timeout }}
-{% if velero_feature_flags|length > 0 %}
+{% if velero_feature_flags is defined %}
             - --features
-{% for flag in velero_feature_flags %}
-            - {{ flag }}
-{% endfor %}
+            - {{ velero_feature_flags }}
 {% endif %}
 {% if velero_debug %}
             - --log-level


### PR DESCRIPTION
This PR does the following:
- Adds support for usage of multiple Velero `--features` flag (comma separated similar to Velero install command )
- Updates Documentation for usage 