### PR TITLE
Update restic template to accept ds node selector

### DIFF
--- a/roles/velero/templates/restic.yml.j2
+++ b/roles/velero/templates/restic.yml.j2
@@ -19,6 +19,11 @@ spec:
       labels:
         name: restic
     spec:
+{% if restic_node_selector is defined %}
+      nodeSelector: {{ restic_node_selector | to_yaml }}
+{% else %}
+      nodeSelector: null
+{% endif %}
       serviceAccountName: velero
       securityContext:
         runAsUser: 0


### PR DESCRIPTION
This PR does the following:
- Adds support for ` nodeSelector` in restic daemonSet template
- Fixes https://github.com/konveyor/oadp-operator/issues/112